### PR TITLE
Update es.json

### DIFF
--- a/es.json
+++ b/es.json
@@ -21,7 +21,7 @@
   "settings.tab_label.display": "Despliegue",
   "settings.tab_label.locale": "Formato",
   "settings.tab_label.sounds": "Sonidos",
-  "settings.units.market_cap": "capitalización",
+  "settings.units.market_cap": "Capital",
   "settings.units.exchange_rate": "Tasa de cambio",
   "settings.display.options": "Opciones de pantalla",
   "settings.display.show_fees_section": "Mostrar tarifas y Mempool",


### PR DESCRIPTION
changing "capitalizacion" to "capital" / "market"

The label is too long and spills onto the calendar UI